### PR TITLE
Add DigitalOcean preview deployment workflow

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,92 @@
+name: DigitalOcean Preview
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install doctl
+        uses: digitalocean/action-doctl@v2
+        with:
+          token: ${{ secrets.DO_API_TOKEN }}
+      - name: Generate app spec
+        id: spec
+        if: github.event.action != 'closed'
+        run: |
+          cat <<'SPEC' > do-app-template.yaml
+alerts:
+- rule: DEPLOYMENT_FAILED
+- rule: DOMAIN_FAILED
+envs:
+- key: REACT_APP_AZURE_KEY
+  scope: RUN_AND_BUILD_TIME
+  value: ${REACT_APP_AZURE_KEY}
+- key: REACT_APP_AZURE_REGION
+  scope: RUN_AND_BUILD_TIME
+  value: ${REACT_APP_AZURE_REGION}
+- key: REACT_APP_PHONEMIZE_API
+  scope: RUN_AND_BUILD_TIME
+  value: ${REACT_APP_PHONEMIZE_API}
+features:
+- buildpack-stack=ubuntu-22
+ingress:
+  rules:
+  - component:
+      name: ipachatreact
+    match:
+      path:
+        prefix: /
+name: ${APP_NAME}
+region: lon
+services:
+- environment_slug: node-js
+  github:
+    branch: ${GITHUB_BRANCH}
+    repo: willwade/IPAChatReact
+    deploy_on_push: false
+  http_port: 8080
+  instance_count: 1
+  instance_size_slug: apps-s-1vcpu-1gb
+  name: ipachatreact
+  run_command: npm start
+  source_dir: /
+SPEC
+          APP_NAME=ipachat-pr-${{ github.event.number }} \
+          GITHUB_BRANCH=${{ github.head_ref }} \
+          REACT_APP_AZURE_KEY=${{ secrets.REACT_APP_AZURE_KEY }} \
+          REACT_APP_AZURE_REGION=${{ secrets.REACT_APP_AZURE_REGION }} \
+          REACT_APP_PHONEMIZE_API=${{ secrets.REACT_APP_PHONEMIZE_API }} \
+          envsubst < do-app-template.yaml > app.yaml
+      - name: Deploy preview
+        id: deploy
+        if: github.event.action != 'closed'
+        env:
+          APP_NAME: ipachat-pr-${{ github.event.number }}
+        run: |
+          APP_ID=$(doctl apps list --format ID,Spec.Name --no-header | awk -v app="$APP_NAME" '$2==app {print $1}')
+          if [ -z "$APP_ID" ]; then
+            APP_ID=$(doctl apps create --spec app.yaml --format ID --no-header)
+          else
+            doctl apps update $APP_ID --spec app.yaml
+          fi
+          doctl apps create-deployment $APP_ID --wait
+          URL=$(doctl apps get $APP_ID --format DefaultIngress --no-header)
+          echo "url=$URL" >> "$GITHUB_OUTPUT"
+      - name: Comment PR
+        if: github.event.action != 'closed'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr comment ${{ github.event.number }} --body "Preview URL: ${{ steps.deploy.outputs.url }}"
+      - name: Destroy preview
+        if: github.event.action == 'closed'
+        env:
+          APP_NAME: ipachat-pr-${{ github.event.number }}
+        run: |
+          APP_ID=$(doctl apps list --format ID,Spec.Name --no-header | awk -v app="$APP_NAME" '$2==app {print $1}')
+          if [ -n "$APP_ID" ]; then
+            doctl apps delete $APP_ID --force --dangerous
+          fi

--- a/README.md
+++ b/README.md
@@ -32,6 +32,25 @@ REACT_APP_AZURE_REGION=your_azure_region_here
 npm start
 ```
 
+## Pull Request Preview Deployments
+
+This repository includes a GitHub Actions workflow that deploys every pull
+request to a temporary DigitalOcean App Platform app. The workflow comments on
+the PR with the preview URL.
+
+To enable preview deployments:
+
+1. Create a DigitalOcean API token with access to manage apps.
+2. Add it to the repository secrets as `DO_API_TOKEN`.
+3. Add the existing Azure environment values as GitHub repository secrets. These
+   should match the values already configured in the DigitalOcean app:
+   - `REACT_APP_AZURE_KEY`
+   - `REACT_APP_AZURE_REGION`
+   - `REACT_APP_PHONEMIZE_API`
+
+No changes are required to the production app. Preview apps are created with a
+unique name per pull request and removed when the PR is closed.
+
 ## Customizing IPA Buttons
 
 Each IPA button can be customized with:


### PR DESCRIPTION
## Summary
- deploy PR previews to DigitalOcean App Platform with automatic PR comments
- document required secrets for preview deployments
- clarify that Azure environment values must be stored as GitHub repository secrets matching the DigitalOcean app

## Testing
- `CI=true npm test -- --passWithNoTests`
- `CI=true npm run build` *(hangs creating production build)*

------
https://chatgpt.com/codex/tasks/task_e_68ad84ddc09883278c8eb2659026bf02