### PR TITLE
Add permissions block to preview workflow

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -4,6 +4,10 @@
   pull_request:
     types: [opened, synchronize, reopened, closed]
 
+permissions:
+  contents: read
+  pull-requests: write   # or issues: write
+
 jobs:
   preview:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- add explicit permissions for contents read and pull request comments in preview workflow

## Testing
- `CI=true npm test -- --passWithNoTests`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad9d0420a88327bd5d36e6d2aa7678