### PR TITLE
Fix background persistence and add toolbar config UI

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -193,6 +193,20 @@ const App = () => {
             // Apply the configuration
             console.log('Applying configuration:', configData);
 
+            // Reset background settings to default if not included in config
+            if (!configData.backgroundSettings) {
+              const defaultBackground = {
+                type: 'color',
+                color: '#ffffff',
+                gradientStart: '#ffffff',
+                gradientEnd: '#000000',
+                gradientDirection: 'to bottom',
+                image: ''
+              };
+              localStorage.setItem('backgroundSettings', JSON.stringify(defaultBackground));
+              console.log('Reset background settings to default');
+            }
+
             // Update localStorage with all the configuration
             Object.entries(configData).forEach(([key, value]) => {
               try {

--- a/src/App.js
+++ b/src/App.js
@@ -1616,6 +1616,8 @@ const App = () => {
               onSpeakWholeUtteranceChange={setSpeakWholeUtterance}
               mode={mode}
               onModeChange={setMode}
+              toolbarConfig={toolbarConfig}
+              onToolbarConfigChange={setToolbarConfig}
             />
 
             {/* Search dialog */}

--- a/src/components/Settings.js
+++ b/src/components/Settings.js
@@ -245,6 +245,20 @@ const Settings = ({
           // Wait a moment for language change to take effect
           await new Promise(resolve => setTimeout(resolve, 100));
 
+          // Reset background settings to default if not included in backup
+          if (!backupData.backgroundSettings) {
+            const defaultBackground = {
+              type: 'color',
+              color: '#ffffff',
+              gradientStart: '#ffffff',
+              gradientEnd: '#000000',
+              gradientDirection: 'to bottom',
+              image: ''
+            };
+            localStorage.setItem('backgroundSettings', JSON.stringify(defaultBackground));
+            console.log('Reset background settings to default during restore');
+          }
+
           // Then update the rest of localStorage
           Object.entries(backupData).forEach(([key, value]) => {
             if (key !== 'selectedLanguage') { // Skip language since we already set it
@@ -304,6 +318,20 @@ const Settings = ({
 
       // Wait a moment for language change to take effect
       await new Promise(resolve => setTimeout(resolve, 100));
+
+      // Reset background settings to default if not included in example
+      if (!data.backgroundSettings) {
+        const defaultBackground = {
+          type: 'color',
+          color: '#ffffff',
+          gradientStart: '#ffffff',
+          gradientEnd: '#000000',
+          gradientDirection: 'to bottom',
+          image: ''
+        };
+        localStorage.setItem('backgroundSettings', JSON.stringify(defaultBackground));
+        console.log('Reset background settings to default when loading example');
+      }
 
       // Then update the rest of localStorage, but force mode to "build"
       Object.entries(data).forEach(([key, value]) => {

--- a/src/components/Settings.js
+++ b/src/components/Settings.js
@@ -74,6 +74,26 @@ const Settings = ({
   const [restoreError, setRestoreError] = useState(null);
   const [isRestoring, setIsRestoring] = useState(false);
 
+  // Helper function to safely update toolbar config
+  const handleToolbarConfigChange = (key, value) => {
+    if (!value) {
+      // Count how many toolbar items are currently visible (excluding settings which is always visible)
+      const visibleCount = Object.entries(toolbarConfig || {})
+        .filter(([k, v]) => k !== 'showSettings' && v !== false)
+        .length;
+
+      // Don't allow disabling if it would leave less than 1 visible item
+      if (visibleCount <= 1) {
+        return;
+      }
+    }
+
+    onToolbarConfigChange(prev => ({
+      ...prev,
+      [key]: value
+    }));
+  };
+
   const handleLanguageChange = (event) => {
     onLanguageChange(event.target.value);
   };

--- a/src/components/Settings.js
+++ b/src/components/Settings.js
@@ -775,10 +775,7 @@ const Settings = ({
                     control={
                       <Switch
                         checked={toolbarConfig?.showBuild !== false}
-                        onChange={(e) => onToolbarConfigChange(prev => ({
-                          ...prev,
-                          showBuild: e.target.checked
-                        }))}
+                        onChange={(e) => handleToolbarConfigChange('showBuild', e.target.checked)}
                       />
                     }
                     label="Build Mode"
@@ -788,10 +785,7 @@ const Settings = ({
                     control={
                       <Switch
                         checked={toolbarConfig?.showSearch !== false}
-                        onChange={(e) => onToolbarConfigChange(prev => ({
-                          ...prev,
-                          showSearch: e.target.checked
-                        }))}
+                        onChange={(e) => handleToolbarConfigChange('showSearch', e.target.checked)}
                       />
                     }
                     label="Search Mode"
@@ -801,10 +795,7 @@ const Settings = ({
                     control={
                       <Switch
                         checked={toolbarConfig?.showBabble !== false}
-                        onChange={(e) => onToolbarConfigChange(prev => ({
-                          ...prev,
-                          showBabble: e.target.checked
-                        }))}
+                        onChange={(e) => handleToolbarConfigChange('showBabble', e.target.checked)}
                       />
                     }
                     label="Babble Mode"
@@ -814,10 +805,7 @@ const Settings = ({
                     control={
                       <Switch
                         checked={toolbarConfig?.showEdit !== false}
-                        onChange={(e) => onToolbarConfigChange(prev => ({
-                          ...prev,
-                          showEdit: e.target.checked
-                        }))}
+                        onChange={(e) => handleToolbarConfigChange('showEdit', e.target.checked)}
                       />
                     }
                     label="Edit Mode"
@@ -827,10 +815,7 @@ const Settings = ({
                     control={
                       <Switch
                         checked={toolbarConfig?.showGame !== false}
-                        onChange={(e) => onToolbarConfigChange(prev => ({
-                          ...prev,
-                          showGame: e.target.checked
-                        }))}
+                        onChange={(e) => handleToolbarConfigChange('showGame', e.target.checked)}
                       />
                     }
                     label="Game Mode"
@@ -850,10 +835,7 @@ const Settings = ({
                     control={
                       <Switch
                         checked={toolbarConfig?.showSetupWizard !== false}
-                        onChange={(e) => onToolbarConfigChange(prev => ({
-                          ...prev,
-                          showSetupWizard: e.target.checked
-                        }))}
+                        onChange={(e) => handleToolbarConfigChange('showSetupWizard', e.target.checked)}
                       />
                     }
                     label="Setup Wizard"

--- a/src/components/Settings.js
+++ b/src/components/Settings.js
@@ -434,7 +434,7 @@ const Settings = ({
                         fontWeight: 600
                       }}
                     >
-                      📁 Load Example Configurations
+                      ��� Load Example Configurations
                     </Typography>
 
                     <Box sx={{
@@ -735,6 +735,120 @@ const Settings = ({
                 }
                 label="Enable Haptic Feedback"
               />
+            </ListItem>
+
+            <Divider />
+
+            <Typography variant="h6" gutterBottom sx={{ mt: 3, px: 2 }}>Advanced Settings</Typography>
+
+            <ListItem>
+              <Box sx={{ width: '100%' }}>
+                <Typography variant="subtitle1" gutterBottom sx={{ fontWeight: 600 }}>
+                  Toolbar Configuration
+                </Typography>
+                <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+                  Control which toolbar buttons are visible in the app
+                </Typography>
+
+                <Box sx={{ display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: 1 }}>
+                  <FormControlLabel
+                    control={
+                      <Switch
+                        checked={toolbarConfig?.showBuild !== false}
+                        onChange={(e) => onToolbarConfigChange(prev => ({
+                          ...prev,
+                          showBuild: e.target.checked
+                        }))}
+                      />
+                    }
+                    label="Build Mode"
+                  />
+
+                  <FormControlLabel
+                    control={
+                      <Switch
+                        checked={toolbarConfig?.showSearch !== false}
+                        onChange={(e) => onToolbarConfigChange(prev => ({
+                          ...prev,
+                          showSearch: e.target.checked
+                        }))}
+                      />
+                    }
+                    label="Search Mode"
+                  />
+
+                  <FormControlLabel
+                    control={
+                      <Switch
+                        checked={toolbarConfig?.showBabble !== false}
+                        onChange={(e) => onToolbarConfigChange(prev => ({
+                          ...prev,
+                          showBabble: e.target.checked
+                        }))}
+                      />
+                    }
+                    label="Babble Mode"
+                  />
+
+                  <FormControlLabel
+                    control={
+                      <Switch
+                        checked={toolbarConfig?.showEdit !== false}
+                        onChange={(e) => onToolbarConfigChange(prev => ({
+                          ...prev,
+                          showEdit: e.target.checked
+                        }))}
+                      />
+                    }
+                    label="Edit Mode"
+                  />
+
+                  <FormControlLabel
+                    control={
+                      <Switch
+                        checked={toolbarConfig?.showGame !== false}
+                        onChange={(e) => onToolbarConfigChange(prev => ({
+                          ...prev,
+                          showGame: e.target.checked
+                        }))}
+                      />
+                    }
+                    label="Game Mode"
+                  />
+
+                  <FormControlLabel
+                    control={
+                      <Switch
+                        checked={toolbarConfig?.showSettings !== false}
+                        onChange={(e) => onToolbarConfigChange(prev => ({
+                          ...prev,
+                          showSettings: e.target.checked
+                        }))}
+                      />
+                    }
+                    label="Settings"
+                  />
+
+                  <FormControlLabel
+                    control={
+                      <Switch
+                        checked={toolbarConfig?.showSetupWizard !== false}
+                        onChange={(e) => onToolbarConfigChange(prev => ({
+                          ...prev,
+                          showSetupWizard: e.target.checked
+                        }))}
+                      />
+                    }
+                    label="Setup Wizard"
+                  />
+                </Box>
+
+                <Alert severity="info" sx={{ mt: 2 }}>
+                  <Typography variant="body2">
+                    Note: At least one toolbar button must remain visible. The Settings button cannot be hidden.
+                  </Typography>
+                </Alert>
+              </Box>
             </ListItem>
           </List>
         </DialogContent>

--- a/src/components/Settings.js
+++ b/src/components/Settings.js
@@ -66,6 +66,8 @@ const Settings = ({
   onSpeakWholeUtteranceChange,
   mode,
   onModeChange,
+  toolbarConfig,
+  onToolbarConfigChange,
 }) => {
   const [restoreDialogOpen, setRestoreDialogOpen] = useState(false);
   const [restoreFile, setRestoreFile] = useState(null);

--- a/src/components/Settings.js
+++ b/src/components/Settings.js
@@ -434,7 +434,7 @@ const Settings = ({
                         fontWeight: 600
                       }}
                     >
-                      ��� Load Example Configurations
+                      📁 Load Example Configurations
                     </Typography>
 
                     <Box sx={{
@@ -819,14 +819,11 @@ const Settings = ({
                   <FormControlLabel
                     control={
                       <Switch
-                        checked={toolbarConfig?.showSettings !== false}
-                        onChange={(e) => onToolbarConfigChange(prev => ({
-                          ...prev,
-                          showSettings: e.target.checked
-                        }))}
+                        checked={true}
+                        disabled={true}
                       />
                     }
-                    label="Settings"
+                    label="Settings (Always Visible)"
                   />
 
                   <FormControlLabel


### PR DESCRIPTION
## Purpose

Based on user feedback, this PR addresses two key issues:

1. **Background persistence bug**: Users reported that background settings were persisting across different configurations when they should be per-config. When loading configurations via URL, onboarding, or settings restore, the background should reset to the config's specified background or default.

2. **Missing toolbar configuration UI**: Users needed a way to show/hide toolbar elements through the settings interface. While this functionality existed in the JSON configuration and could be loaded from URLs/restore, there was no user-facing UI to control it.

## Code changes

### Background Settings Reset
- Added logic to reset background settings to default when loading configurations that don't include `backgroundSettings`
- Implemented in three places: URL config loading, settings restore, and example loading
- Default background is set to white color with fallback gradient options

### Advanced Toolbar Configuration UI
- Added new "Advanced Settings" section in Settings dialog
- Created grid-based UI with switches for each toolbar button (Build, Search, Babble, Edit, Game, Setup Wizard)
- Settings button is always visible and disabled (cannot be hidden)
- Added safety check to prevent hiding all toolbar buttons (minimum 1 must remain visible)
- Passed `toolbarConfig` and `onToolbarConfigChange` props from App to Settings component
- Added informational alert explaining the constraints

### Technical Implementation
- Enhanced `handleToolbarConfigChange` function with validation logic
- Used Material-UI components (Switch, FormControlLabel, Alert) for consistent styling
- Maintained backward compatibility with existing toolbar configurations

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 19`

🔗 [Edit in Builder.io](https://builder.io/app/projects/5e3ca183bf8a458589248406d45fba94/vortex-oasis)

👀 [Preview Link](https://5e3ca183bf8a458589248406d45fba94-vortex-oasis.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>5e3ca183bf8a458589248406d45fba94</projectId>-->
<!--<branchName>vortex-oasis</branchName>-->