### PR TITLE
feat: add option to clear message bar after play

### DIFF
--- a/src/components/IPAKeyboard.js
+++ b/src/components/IPAKeyboard.js
@@ -960,6 +960,8 @@ const IPAKeyboard = ({
                 e.stopPropagation();
                 handlePhonemeMove(phoneme, 'up');
               }}
+              onMouseDown={(e) => e.stopPropagation()}
+              onTouchStart={(e) => e.stopPropagation()}
               sx={{
                 position: 'absolute',
                 top: -9,
@@ -1001,6 +1003,8 @@ const IPAKeyboard = ({
                 e.stopPropagation();
                 handlePhonemeMove(phoneme, 'down');
               }}
+              onMouseDown={(e) => e.stopPropagation()}
+              onTouchStart={(e) => e.stopPropagation()}
               sx={{
                 position: 'absolute',
                 bottom: -9,
@@ -1041,7 +1045,9 @@ const IPAKeyboard = ({
                 e.stopPropagation();
                 handlePhonemeMove(phoneme, 'left');
               }}
-              sx={{ 
+              onMouseDown={(e) => e.stopPropagation()}
+              onTouchStart={(e) => e.stopPropagation()}
+              sx={{
                 position: 'absolute',
                 top: '50%',
                 left: -9,
@@ -1080,7 +1086,9 @@ const IPAKeyboard = ({
                 e.stopPropagation();
                 handlePhonemeMove(phoneme, 'right');
               }}
-              sx={{ 
+              onMouseDown={(e) => e.stopPropagation()}
+              onTouchStart={(e) => e.stopPropagation()}
+              sx={{
                 position: 'absolute',
                 top: '50%',
                 right: -9,

--- a/src/components/Settings.js
+++ b/src/components/Settings.js
@@ -66,6 +66,8 @@ const Settings = ({
   onSpeakOnButtonPressChange,
   speakWholeUtterance,
   onSpeakWholeUtteranceChange,
+  clearMessageAfterPlay,
+  onClearMessageAfterPlayChange,
   mode,
   onModeChange,
   toolbarConfig,
@@ -782,6 +784,23 @@ const Settings = ({
                   label="Read whole utterance as it's built"
                 />
                 <Tooltip title="Automatically speak the entire message when the message bar is updated in build mode">
+                  <IconButton size="small" sx={{ ml: 1 }}>
+                    <HelpOutlineIcon fontSize="small" />
+                  </IconButton>
+                </Tooltip>
+              </Box>
+
+              <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
+                <FormControlLabel
+                  control={
+                    <Switch
+                      checked={clearMessageAfterPlay}
+                      onChange={(e) => onClearMessageAfterPlayChange(e.target.checked)}
+                    />
+                  }
+                  label="Clear message bar after playing"
+                />
+                <Tooltip title="After speaking a message in build mode, clear the message bar and show an undo option">
                   <IconButton size="small" sx={{ ml: 1 }}>
                     <HelpOutlineIcon fontSize="small" />
                   </IconButton>


### PR DESCRIPTION
## Summary
- add setting to clear the message bar after playing in build mode
- replace play button with undo button when message is cleared
- allow restoring last spoken message from undo button
- prevent move handles from hiding buttons in edit mode by stopping touch and mouse events from reaching the button

## Testing
- `CI=true npm test -- --passWithNoTests`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bbff6b2df88327a5e9ba7701c816a3