### PR TITLE
check for explicit grid config for #columns

### DIFF
--- a/src/components/IPAKeyboard.js
+++ b/src/components/IPAKeyboard.js
@@ -100,6 +100,12 @@ const IPAKeyboard = ({
   const getFixedLayoutColumns = useCallback(() => {
     if (!fixedLayout) return null;
 
+    // First check if there's an explicit gridConfig for this language
+    const customConfig = gridConfig?.[validLanguage];
+    if (customConfig?.columns) {
+      return customConfig.columns;
+    }
+
     const savedOrder = phonemeOrder[validLanguage];
     if (!savedOrder || !Array.isArray(savedOrder)) return null;
 
@@ -125,7 +131,7 @@ const IPAKeyboard = ({
     }
 
     return null;
-  }, [fixedLayout, phonemeOrder, validLanguage]);
+  }, [fixedLayout, phonemeOrder, validLanguage, gridConfig]);
 
   // Check if we should use fixed layout
   const shouldUseFixedLayout = useCallback(() => {


### PR DESCRIPTION
not sure if this is in the plan, but it makes it work for now, so qwerty looks right. Other pagesets do not use `gridConfig` so it shouldn't impact them 